### PR TITLE
feat: support for input_boolean entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/node_modules
 dist/
 *.log
+.idea/

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -5,6 +5,7 @@ import { OnOffToggle } from './util'
 
 export enum ActionId {
   SetSwitch = 'set_switch',
+  SetInputBoolean = 'set_input_boolean',
   SetLightOn = 'set_light_on',
   ExecuteScript = 'execute_script'
 }
@@ -48,6 +49,11 @@ export function GetActionsList(
     [ActionId.SetSwitch]: {
       label: 'Set switch state',
       options: [EntityPicker(initialState, 'switch'), OnOffTogglePicker()],
+      callback: (evt): void => entityOnOff(evt.options)
+    },
+    [ActionId.SetInputBoolean]: {
+      label: 'Set input_boolean state',
+      options: [EntityPicker(initialState, 'input_boolean'), OnOffTogglePicker()],
       callback: (evt): void => entityOnOff(evt.options)
     },
     [ActionId.SetLightOn]: {

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -12,6 +12,7 @@ import { DeviceConfig } from './config'
 
 export enum FeedbackId {
   SwitchState = 'switch_state',
+  InputBooleanState = 'input_boolean_state',
   LightOnState = 'light_on_state',
   BinarySensorState = 'binary_sensor_state'
 }
@@ -66,6 +67,17 @@ export function GetFeedbacksList(
         ForegroundPicker(instance.rgb(255, 255, 255)),
         BackgroundPicker(instance.rgb(0, 255, 0)),
         EntityPicker(initialState, 'switch'),
+        OnOffPicker()
+      ],
+      callback: (feedback): CompanionFeedbackResult => checkEntityOnOffState(feedback)
+    },
+    [FeedbackId.InputBooleanState]: {
+      label: 'Change colors from input_boolean state',
+      description: 'If the input_boolean state matches the rule, change colors of the bank',
+      options: [
+        ForegroundPicker(instance.rgb(255, 255, 255)),
+        BackgroundPicker(instance.rgb(0, 255, 0)),
+        EntityPicker(initialState, 'input_boolean'),
         OnOffPicker()
       ],
       callback: (feedback): CompanionFeedbackResult => checkEntityOnOffState(feedback)

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -57,6 +57,42 @@ export function GetPresetsList(instance: InstanceSkel<DeviceConfig>, state: Hass
       ]
     })
   })
+
+  const inputBooleanPicker = EntityPicker(state, 'input_boolean')
+  inputBooleanPicker.choices.forEach(ent => {
+    presets.push({
+      category: 'Input Boolean',
+      label: `Input Boolean ${ent.label}`,
+      bank: {
+        style: 'text',
+        text: `$(homeassistant-server:entity.${ent.id})`,
+        size: 'auto',
+        color: instance.rgb(255, 255, 255),
+        bgcolor: instance.rgb(0, 0, 0)
+      },
+      feedbacks: [
+        {
+          type: FeedbackId.InputBooleanState,
+          options: {
+            bg: instance.rgb(0, 255, 0),
+            fg: instance.rgb(255, 255, 255),
+            entity_id: ent.id,
+            state: true
+          }
+        }
+      ],
+      actions: [
+        {
+          action: ActionId.SetInputBoolean,
+          options: {
+            entity_id: ent.id,
+            state: OnOffToggle.Toggle
+          }
+        }
+      ]
+    })
+  })
+
   const lightPicker = EntityPicker(state, 'light')
   lightPicker.choices.forEach(ent => {
     presets.push({


### PR DESCRIPTION
Input Booleans are virtual switches in Home Assistant. This adds support for handling them the exact same way as switches supporting:

- toggling their state
- using their state as feedback to color the button