### PR TITLE
Restructured the variables to include actual state

### DIFF
--- a/src/variables.ts
+++ b/src/variables.ts
@@ -7,7 +7,7 @@ export function updateVariables(instance: InstanceSkel<DeviceConfig>, state: Has
 	const variables: { [variableId: string]: string | undefined } = {}
 	for (const entity of Object.values(state)) {
 		variables[`entity.${entity.entity_id}.value`] = entity.state;
-		variables[`entity.${entity.entity_id}.name`] = entity.attributes.friendly_name ?? entity.entity_id;
+		variables[`entity.${entity.entity_id}`] = entity.attributes.friendly_name ?? entity.entity_id;
 	}
 
 	instance.setVariables(variables)
@@ -23,7 +23,7 @@ export function InitVariables(instance: InstanceSkel<DeviceConfig>, state: HassE
 		});
 		variables.push({
 			label: `Entity: ${entity.attributes.friendly_name ?? entity.entity_id}`,
-			name: `entity.${entity.entity_id}.name`,
+			name: `entity.${entity.entity_id}`,
 		});
 	}
 	instance.setVariableDefinitions(variables)

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -6,7 +6,8 @@ import { DeviceConfig } from './config'
 export function updateVariables(instance: InstanceSkel<DeviceConfig>, state: HassEntities): void {
 	const variables: { [variableId: string]: string | undefined } = {}
 	for (const entity of Object.values(state)) {
-		variables[`entity.${entity.entity_id}`] = entity.attributes.friendly_name ?? entity.entity_id
+		variables[`entity.${entity.entity_id}.value`] = entity.state;
+		variables[`entity.${entity.entity_id}.name`] = entity.attributes.friendly_name ?? entity.entity_id;
 	}
 
 	instance.setVariables(variables)
@@ -17,10 +18,13 @@ export function InitVariables(instance: InstanceSkel<DeviceConfig>, state: HassE
 
 	for (const entity of Object.values(state)) {
 		variables.push({
+			label: `Entity: ${(_a = entity.attributes.friendly_name) !== null && _a !== void 0 ? _a : entity.entity_id}`,
+			name: `entity.${entity.entity_id}.value`,
+		});
+		variables.push({
 			label: `Entity: ${entity.attributes.friendly_name ?? entity.entity_id}`,
-			name: `entity.${entity.entity_id}`,
-		})
+			name: `entity.${entity.entity_id}.name`,
+		});
 	}
-
 	instance.setVariableDefinitions(variables)
 }


### PR DESCRIPTION
Removed the default variable for each entity, added 2 variables in its place. One containing the friendly name (as it previously was) and another variable as the actual state of the variable. (as mentioned in https://github.com/bitfocus/companion-module-homeassistant-server/issues/6 ).