### PR TITLE
feat: Add value variable

### DIFF
--- a/src/variables.ts
+++ b/src/variables.ts
@@ -7,7 +7,7 @@ export function updateVariables(instance: InstanceSkel<DeviceConfig>, state: Has
 	const variables: { [variableId: string]: string | undefined } = {}
 	for (const entity of Object.values(state)) {
 		variables[`entity.${entity.entity_id}.value`] = entity.state;
-		variables[`entity.${entity.entity_id}.name`] = entity.attributes.friendly_name ?? entity.entity_id;
+		variables[`entity.${entity.entity_id}`] = entity.attributes.friendly_name ?? entity.entity_id;
 	}
 
 	instance.setVariables(variables)
@@ -23,7 +23,7 @@ export function InitVariables(instance: InstanceSkel<DeviceConfig>, state: HassE
 		});
 		variables.push({
 			label: `Entity: ${entity.attributes.friendly_name ?? entity.entity_id}`,
-			name: `entity.${entity.entity_id}.name`,
+			name: `entity.${entity.entity_id}`,
 		});
 	}
 	instance.setVariableDefinitions(variables)

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -6,7 +6,8 @@ import { DeviceConfig } from './config'
 export function updateVariables(instance: InstanceSkel<DeviceConfig>, state: HassEntities): void {
 	const variables: { [variableId: string]: string | undefined } = {}
 	for (const entity of Object.values(state)) {
-		variables[`entity.${entity.entity_id}`] = entity.attributes.friendly_name ?? entity.entity_id
+		variables[`entity.${entity.entity_id}.value`] = entity.state;
+		variables[`entity.${entity.entity_id}.name`] = entity.attributes.friendly_name ?? entity.entity_id;
 	}
 
 	instance.setVariables(variables)
@@ -17,10 +18,13 @@ export function InitVariables(instance: InstanceSkel<DeviceConfig>, state: HassE
 
 	for (const entity of Object.values(state)) {
 		variables.push({
+			label: `Entity: ${(_a = entity.attributes.friendly_name) !== null && _a !== void 0 ? _a : entity.entity_id}`,
+			name: `entity.${entity.entity_id}.value`,
+		});
+		variables.push({
 			label: `Entity: ${entity.attributes.friendly_name ?? entity.entity_id}`,
-			name: `entity.${entity.entity_id}`,
-		})
+			name: `entity.${entity.entity_id}.name`,
+		});
 	}
-
 	instance.setVariableDefinitions(variables)
 }


### PR DESCRIPTION
This commit reflects the addition of a .value variable, while leaving the old style variable intact. This is only done for backwards compatibility and any extensions to the variables should be made in new style to prevent conflicts further down the line. According to Home Assistant manuals there are other optional variables which can be used. see https://www.home-assistant.io/docs/configuration/state_object for more information about the available attributes.