### PR TITLE
feat: report Call Service failures to the Companion log

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ While developing the module, by using `yarn dev` the compiler will be run in wat
 
 ## Changes
 
+### Unreleased
+
+- Report Call Service failures to the Companion log instead of swallowing them
+
 ### v2.0.3
 
 - Fix bad merge

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -97,7 +97,12 @@ export type ActionsSchema = {
 }
 
 export function GetActionsList(
-	getProps: () => { state: HassEntity[]; services: HassServices; client: Connection | undefined },
+	getProps: () => {
+		state: HassEntity[]
+		services: HassServices
+		client: Connection | undefined
+		log?: (level: 'debug' | 'info' | 'warn' | 'error', message: string) => void
+	},
 ): CompanionActionDefinitions<ActionsSchema> {
 	const entityOnOff = async (opt: CompanionActionEvent['options']): Promise<void> => {
 		const { client } = getProps()
@@ -333,7 +338,7 @@ export function GetActionsList(
 				},
 			],
 			callback: async (evt) => {
-				const { client } = getProps()
+				const { client, log } = getProps()
 				if (!client) return
 
 				try {
@@ -365,7 +370,8 @@ export function GetActionsList(
 
 					await callService(client, domain, service, payload, target)
 				} catch (e) {
-					console.debug(`Call service failed: ${e}`)
+					const message = e instanceof Error ? e.message : String(e)
+					log?.('warn', `Call service '${evt.options.service}' failed: ${message}`)
 				}
 			},
 		},

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,12 @@ export default class ControllerInstance extends InstanceBase<HassSchema> {
 		this.setPresetDefinitions(...GetPresetsList(this.state))
 		this.setFeedbackDefinitions(GetFeedbacksList(this.state, () => this.stateObj, this.entitySubscriptions))
 		this.setActionDefinitions(
-			GetActionsList(() => ({ state: this.state, services: this.services, client: this.client })),
+			GetActionsList(() => ({
+				state: this.state,
+				services: this.services,
+				client: this.client,
+				log: (level, message) => this.log(level, message),
+			})),
 		)
 		// updateVariables(this, this.state) No need, there are no entities
 	}
@@ -297,7 +302,12 @@ export default class ControllerInstance extends InstanceBase<HassSchema> {
 				this.setPresetDefinitions(...GetPresetsList(this.state))
 				this.setFeedbackDefinitions(GetFeedbacksList(this.state, () => this.stateObj, this.entitySubscriptions))
 				this.setActionDefinitions(
-					GetActionsList(() => ({ state: this.state, client: this.client, services: this.services })),
+					GetActionsList(() => ({
+						state: this.state,
+						client: this.client,
+						services: this.services,
+						log: (level, message) => this.log(level, message),
+					})),
 				)
 				InitVariables(this, this.state)
 			}
@@ -340,7 +350,12 @@ export default class ControllerInstance extends InstanceBase<HassSchema> {
 		this.services = services
 
 		this.setActionDefinitions(
-			GetActionsList(() => ({ state: this.state, client: this.client, services: this.services })),
+			GetActionsList(() => ({
+				state: this.state,
+				client: this.client,
+				services: this.services,
+				log: (level, message) => this.log(level, message),
+			})),
 		)
 	}
 }


### PR DESCRIPTION
### What

The `Call Service` action previously swallowed errors with `console.debug(...)`, which never surfaces in the Companion UI. This plumbs an optional logger into `GetActionsList` and reports failures via `this.log('warn', ...)`, so users can see when and why a service call failed.

### Why

`console.debug` output is invisible in normal Companion operation, so a malformed payload or invalid service currently fails silently with no feedback to the user.

### Notes

Small, self-contained change with no new actions/feedbacks. Part of a small series adding cover/lock/climate support; this one stands alone and can merge independently. `yarn build` and `yarn lint` pass.