### PR TITLE
feat: add support for input_number entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ While developing the module, by using `yarn dev` the compiler will be run in wat
 
 ## Changes
 
+### Unreleased
+
+- Add support for input_number entities: set value, increment, decrement and adjust-by-amount actions, plus a value comparison feedback
+
 ### v2.0.3
 
 - Fix bad merge

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -24,6 +24,10 @@
 - Input Select: Previous
 - Input Select: Select
 - Set group on/off state
+- Input Number: Set value
+- Input Number: Increment
+- Input Number: Decrement
+- Input Number: Adjust by amount
 - Call Service
 
 **Available feedbacks**
@@ -34,6 +38,7 @@
 - Binary sensor state
 - Input select state
 - Group on state
+- Input number value
 
 **Available variables**
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -87,6 +87,28 @@ export type ActionsSchema = {
 			state: OnOffToggle
 		}
 	}
+	input_number_set: {
+		options: {
+			entity_id: string[]
+			value: number
+		}
+	}
+	input_number_increment: {
+		options: {
+			entity_id: string[]
+		}
+	}
+	input_number_decrement: {
+		options: {
+			entity_id: string[]
+		}
+	}
+	input_number_adjust: {
+		options: {
+			entity_id: string[]
+			delta: number
+		}
+	}
 	call_service: {
 		options: {
 			entity_id: string[]
@@ -309,6 +331,94 @@ export function GetActionsList(
 			name: 'Set group on/off state',
 			options: [EntityMultiplePicker(initialState, 'group'), OnOffTogglePicker()],
 			callback: async (evt) => entityOnOff(evt.options),
+		},
+		input_number_set: {
+			name: 'Input Number: Set value',
+			options: [
+				EntityMultiplePicker(initialState, 'input_number'),
+				{
+					type: 'number',
+					label: 'Value',
+					id: 'value',
+					default: 0,
+					min: -1000000,
+					max: 1000000,
+					step: 1,
+				},
+			],
+			callback: async (evt) => {
+				const { client } = getProps()
+				if (!client) return
+
+				await callService(client, 'input_number', 'set_value', {
+					entity_id: evt.options.entity_id,
+					value: Number(evt.options.value),
+				})
+			},
+		},
+		input_number_increment: {
+			name: 'Input Number: Increment',
+			options: [EntityMultiplePicker(initialState, 'input_number')],
+			callback: async (evt) => {
+				const { client } = getProps()
+				if (!client) return
+
+				await callService(client, 'input_number', 'increment', {
+					entity_id: evt.options.entity_id,
+				})
+			},
+		},
+		input_number_decrement: {
+			name: 'Input Number: Decrement',
+			options: [EntityMultiplePicker(initialState, 'input_number')],
+			callback: async (evt) => {
+				const { client } = getProps()
+				if (!client) return
+
+				await callService(client, 'input_number', 'decrement', {
+					entity_id: evt.options.entity_id,
+				})
+			},
+		},
+		input_number_adjust: {
+			name: 'Input Number: Adjust by amount',
+			options: [
+				EntityMultiplePicker(initialState, 'input_number'),
+				{
+					type: 'number',
+					label: 'Adjustment (added to the current value)',
+					id: 'delta',
+					default: 1,
+					min: -1000000,
+					max: 1000000,
+					step: 1,
+				},
+			],
+			callback: async (evt) => {
+				const { client, state } = getProps()
+				if (!client) return
+
+				const delta = Number(evt.options.delta)
+				for (const entityId of evt.options.entity_id) {
+					const entity = state.find((ent) => ent.entity_id === entityId)
+					if (!entity) continue
+
+					const current = Number(entity.state)
+					if (!Number.isFinite(current)) continue
+
+					let next = current + delta
+					// Respect the helper's configured bounds when they are known
+					const min = Number(entity.attributes.min)
+					const max = Number(entity.attributes.max)
+					if (Number.isFinite(min)) next = Math.max(min, next)
+					if (Number.isFinite(max)) next = Math.min(max, next)
+
+					await callService(client, 'input_number', 'set_value', {
+						entity_id: entityId,
+						value: next,
+					})
+				}
+			},
 		},
 		call_service: {
 			name: 'Call Service',

--- a/src/choices.ts
+++ b/src/choices.ts
@@ -34,6 +34,26 @@ export function OnOffPicker(): CompanionInputFieldCheckbox<'state'> {
 	}
 }
 
+export const NUMBER_COMPARATORS = ['==', '!=', '<', '<=', '>', '>='] as const
+
+export function NumberComparatorPicker(): CompanionInputFieldDropdown<'comparator'> {
+	const options = [
+		{ id: '==', label: 'Equal to' },
+		{ id: '!=', label: 'Not equal to' },
+		{ id: '<', label: 'Less than' },
+		{ id: '<=', label: 'Less than or equal to' },
+		{ id: '>', label: 'Greater than' },
+		{ id: '>=', label: 'Greater than or equal to' },
+	]
+	return {
+		type: 'dropdown',
+		label: 'Comparison',
+		id: 'comparator',
+		default: '>=',
+		choices: options,
+	}
+}
+
 function EntityOptions(state: HassEntity[], prefix: string | undefined): DropdownChoice<string>[] {
 	const entities = state.filter((ent) => prefix === undefined || ent.entity_id.indexOf(`${prefix}.`) === 0)
 

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -4,7 +4,7 @@ import type {
 	CompanionFeedbackInfo,
 } from '@companion-module/base'
 import type { HassEntities, HassEntity } from 'home-assistant-js-websocket'
-import { EntityPicker, OnOffPicker } from './choices.js'
+import { EntityPicker, NumberComparatorPicker, OnOffPicker } from './choices.js'
 import { EntitySubscriptions } from './state.js'
 
 export type FeedbackId = keyof FeedbacksSchema
@@ -50,6 +50,14 @@ export type FeedbacksSchema = {
 		options: {
 			entity_id: string
 			state: boolean
+		}
+	}
+	input_number_value: {
+		type: 'boolean'
+		options: {
+			entity_id: string
+			comparator: string
+			value: number
 		}
 	}
 }
@@ -181,6 +189,56 @@ export function GetFeedbacksList(
 			callback: (feedback): boolean => {
 				subscribeEntityPicker(feedback)
 				return checkEntityOnOffState(feedback)
+			},
+			unsubscribe: unsubscribeEntityPicker,
+		},
+		input_number_value: {
+			type: 'boolean',
+			name: 'Change from input number value',
+			description: 'If the input number value compares to the target as selected',
+			options: [
+				EntityPicker(initialState, 'input_number'),
+				NumberComparatorPicker(),
+				{
+					type: 'number',
+					label: 'Value',
+					id: 'value',
+					default: 0,
+					min: -1000000,
+					max: 1000000,
+					step: 1,
+				},
+			],
+			defaultStyle: {
+				color: 0x000000,
+				bgcolor: 0x00ff00,
+			},
+			callback: (feedback): boolean => {
+				subscribeEntityPicker(feedback)
+				const state = getState()
+				const entity = state[feedback.options.entity_id]
+				if (!entity) return false
+
+				const current = Number(entity.state)
+				const target = Number(feedback.options.value)
+				if (!Number.isFinite(current) || !Number.isFinite(target)) return false
+
+				switch (feedback.options.comparator) {
+					case '==':
+						return current === target
+					case '!=':
+						return current !== target
+					case '<':
+						return current < target
+					case '<=':
+						return current <= target
+					case '>':
+						return current > target
+					case '>=':
+						return current >= target
+					default:
+						return false
+				}
 			},
 			unsubscribe: unsubscribeEntityPicker,
 		},


### PR DESCRIPTION
### What

First-class support for `input_number` helper entities:

**Actions**
- Input Number: Set value (`input_number.set_value`)
- Input Number: Increment (`input_number.increment` — steps by the helper's configured step)
- Input Number: Decrement (`input_number.decrement`)
- Input Number: Adjust by amount — reads the current value and calls `set_value` with `current + delta`, clamped to the helper's configured `min`/`max` when known

**Feedback**
- Input number value — compares the current value against a target using a selectable operator (`=`, `≠`, `<`, `≤`, `>`, `≥`)

### Notes

The current value is already available via the existing `entity.<id>.value` variable, so no new variables are added. Increment/decrement mirror the buttons in the Home Assistant UI (fixed step), while Adjust by amount allows a custom delta.

### Testing

`yarn build` and `yarn lint` pass. HELP.md and the README changelog are updated.