### PR TITLE
feat: add support for media_player entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ While developing the module, by using `yarn dev` the compiler will be run in wat
 
 ## Changes
 
+### Unreleased
+
+- Add support for media_player entities: set playback (play/pause/stop), next/previous track, mute/unmute/toggle, volume up/down/set/adjust and power on/off/toggle actions, plus playback state and mute state feedbacks
+
 ### v2.0.3
 
 - Fix bad merge

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -24,6 +24,15 @@
 - Input Select: Previous
 - Input Select: Select
 - Set group on/off state
+- Media: Set playback (play / pause / play-pause / stop)
+- Media: Next track
+- Media: Previous track
+- Media: Set mute (mute / unmute / toggle)
+- Media: Volume up
+- Media: Volume down
+- Media: Set volume (percentage)
+- Media: Adjust volume by amount (percentage)
+- Media: Set power (on / off / toggle)
 - Call Service
 
 **Available feedbacks**
@@ -34,6 +43,8 @@
 - Binary sensor state
 - Input select state
 - Group on state
+- Media player playback state
+- Media player mute state
 
 **Available variables**
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -6,8 +6,8 @@ import {
 	type HassServiceTarget,
 } from 'home-assistant-js-websocket'
 import type { CompanionActionEvent, CompanionActionDefinitions, DropdownChoice } from '@companion-module/base'
-import { EntityMultiplePicker, OnOffTogglePicker } from './choices.js'
-import { OnOffToggle } from './util.js'
+import { EntityMultiplePicker, MediaMutePicker, MediaPlaybackPicker, OnOffTogglePicker } from './choices.js'
+import { MediaPlayback, MuteToggle, OnOffToggle } from './util.js'
 
 export type ActionsSchema = {
 	set_switch: {
@@ -82,6 +82,56 @@ export type ActionsSchema = {
 		}
 	}
 	set_group_on: {
+		options: {
+			entity_id: string[]
+			state: OnOffToggle
+		}
+	}
+	media_set_playback: {
+		options: {
+			entity_id: string[]
+			action: MediaPlayback
+		}
+	}
+	media_next_track: {
+		options: {
+			entity_id: string[]
+		}
+	}
+	media_previous_track: {
+		options: {
+			entity_id: string[]
+		}
+	}
+	media_set_mute: {
+		options: {
+			entity_id: string[]
+			state: MuteToggle
+		}
+	}
+	media_volume_up: {
+		options: {
+			entity_id: string[]
+		}
+	}
+	media_volume_down: {
+		options: {
+			entity_id: string[]
+		}
+	}
+	media_set_volume: {
+		options: {
+			entity_id: string[]
+			volume: number
+		}
+	}
+	media_volume_adjust: {
+		options: {
+			entity_id: string[]
+			delta: number
+		}
+	}
+	media_set_power: {
 		options: {
 			entity_id: string[]
 			state: OnOffToggle
@@ -309,6 +359,192 @@ export function GetActionsList(
 			name: 'Set group on/off state',
 			options: [EntityMultiplePicker(initialState, 'group'), OnOffTogglePicker()],
 			callback: async (evt) => entityOnOff(evt.options),
+		},
+		media_set_playback: {
+			name: 'Media: Set playback',
+			options: [EntityMultiplePicker(initialState, 'media_player'), MediaPlaybackPicker()],
+			callback: async (evt) => {
+				const { client } = getProps()
+				if (!client) return
+
+				let service: string
+				switch (evt.options.action) {
+					case MediaPlayback.Play:
+						service = 'media_play'
+						break
+					case MediaPlayback.Pause:
+						service = 'media_pause'
+						break
+					case MediaPlayback.Stop:
+						service = 'media_stop'
+						break
+					default:
+						service = 'media_play_pause'
+						break
+				}
+
+				await callService(client, 'media_player', service, {
+					entity_id: evt.options.entity_id,
+				})
+			},
+		},
+		media_next_track: {
+			name: 'Media: Next track',
+			options: [EntityMultiplePicker(initialState, 'media_player')],
+			callback: async (evt) => {
+				const { client } = getProps()
+				if (!client) return
+
+				await callService(client, 'media_player', 'media_next_track', {
+					entity_id: evt.options.entity_id,
+				})
+			},
+		},
+		media_previous_track: {
+			name: 'Media: Previous track',
+			options: [EntityMultiplePicker(initialState, 'media_player')],
+			callback: async (evt) => {
+				const { client } = getProps()
+				if (!client) return
+
+				await callService(client, 'media_player', 'media_previous_track', {
+					entity_id: evt.options.entity_id,
+				})
+			},
+		},
+		media_set_mute: {
+			name: 'Media: Set mute',
+			options: [EntityMultiplePicker(initialState, 'media_player'), MediaMutePicker()],
+			callback: async (evt) => {
+				const { client, state } = getProps()
+				if (!client) return
+
+				const mode = evt.options.state
+				for (const entityId of evt.options.entity_id) {
+					let muted: boolean
+					if (mode === MuteToggle.Toggle) {
+						// media_player has no mute toggle service, so invert the current mute state
+						const entity = state.find((ent) => ent.entity_id === entityId)
+						muted = !(entity?.attributes.is_volume_muted ?? false)
+					} else {
+						muted = mode === MuteToggle.Mute
+					}
+
+					await callService(client, 'media_player', 'volume_mute', {
+						entity_id: entityId,
+						is_volume_muted: muted,
+					})
+				}
+			},
+		},
+		media_volume_up: {
+			name: 'Media: Volume up',
+			options: [EntityMultiplePicker(initialState, 'media_player')],
+			callback: async (evt) => {
+				const { client } = getProps()
+				if (!client) return
+
+				await callService(client, 'media_player', 'volume_up', {
+					entity_id: evt.options.entity_id,
+				})
+			},
+		},
+		media_volume_down: {
+			name: 'Media: Volume down',
+			options: [EntityMultiplePicker(initialState, 'media_player')],
+			callback: async (evt) => {
+				const { client } = getProps()
+				if (!client) return
+
+				await callService(client, 'media_player', 'volume_down', {
+					entity_id: evt.options.entity_id,
+				})
+			},
+		},
+		media_set_volume: {
+			name: 'Media: Set volume (percentage)',
+			options: [
+				EntityMultiplePicker(initialState, 'media_player'),
+				{
+					type: 'number',
+					label: 'Volume (0 = min, 100 = max)',
+					id: 'volume',
+					default: 50,
+					min: 0,
+					max: 100,
+					step: 1,
+					range: true,
+				},
+			],
+			callback: async (evt) => {
+				const { client } = getProps()
+				if (!client) return
+
+				const level = Math.min(1, Math.max(0, Number(evt.options.volume) / 100))
+				await callService(client, 'media_player', 'volume_set', {
+					entity_id: evt.options.entity_id,
+					volume_level: level,
+				})
+			},
+		},
+		media_volume_adjust: {
+			name: 'Media: Adjust volume by amount (percentage)',
+			options: [
+				EntityMultiplePicker(initialState, 'media_player'),
+				{
+					type: 'number',
+					label: 'Adjustment (percentage points, added to the current volume)',
+					id: 'delta',
+					default: 5,
+					min: -100,
+					max: 100,
+					step: 1,
+				},
+			],
+			callback: async (evt) => {
+				const { client, state } = getProps()
+				if (!client) return
+
+				const delta = Number(evt.options.delta) / 100
+				for (const entityId of evt.options.entity_id) {
+					const entity = state.find((ent) => ent.entity_id === entityId)
+					if (!entity) continue
+
+					const current = Number(entity.attributes.volume_level)
+					if (!Number.isFinite(current)) continue
+
+					const next = Math.min(1, Math.max(0, current + delta))
+					await callService(client, 'media_player', 'volume_set', {
+						entity_id: entityId,
+						volume_level: next,
+					})
+				}
+			},
+		},
+		media_set_power: {
+			name: 'Media: Set power',
+			options: [EntityMultiplePicker(initialState, 'media_player'), OnOffTogglePicker()],
+			callback: async (evt) => {
+				const { client } = getProps()
+				if (!client) return
+
+				let service: string
+				switch (evt.options.state) {
+					case OnOffToggle.On:
+						service = 'turn_on'
+						break
+					case OnOffToggle.Off:
+						service = 'turn_off'
+						break
+					default:
+						service = 'toggle'
+						break
+				}
+
+				await callService(client, 'media_player', service, {
+					entity_id: evt.options.entity_id,
+				})
+			},
 		},
 		call_service: {
 			name: 'Call Service',

--- a/src/choices.ts
+++ b/src/choices.ts
@@ -5,7 +5,7 @@ import {
 	DropdownChoice,
 } from '@companion-module/base'
 import type { HassEntity } from 'home-assistant-js-websocket'
-import { OnOffToggle } from './util.js'
+import { MediaPlayback, MuteToggle, OnOffToggle } from './util.js'
 
 export const LIGHT_MAX_BRIGHTNESS = 255
 
@@ -31,6 +31,53 @@ export function OnOffPicker(): CompanionInputFieldCheckbox<'state'> {
 		label: 'State',
 		id: 'state',
 		default: true,
+	}
+}
+
+export function MediaPlaybackPicker(): CompanionInputFieldDropdown<'action'> {
+	const options = [
+		{ id: MediaPlayback.Play, label: 'Play' },
+		{ id: MediaPlayback.Pause, label: 'Pause' },
+		{ id: MediaPlayback.PlayPause, label: 'Play / Pause (toggle)' },
+		{ id: MediaPlayback.Stop, label: 'Stop' },
+	]
+	return {
+		type: 'dropdown',
+		label: 'Action',
+		id: 'action',
+		default: MediaPlayback.PlayPause,
+		choices: options,
+		disableAutoExpression: true,
+	}
+}
+
+export function MediaMutePicker(): CompanionInputFieldDropdown<'state'> {
+	const options = [
+		{ id: MuteToggle.Mute, label: 'Mute' },
+		{ id: MuteToggle.Unmute, label: 'Unmute' },
+		{ id: MuteToggle.Toggle, label: 'Toggle' },
+	]
+	return {
+		type: 'dropdown',
+		label: 'Action',
+		id: 'state',
+		default: MuteToggle.Mute,
+		choices: options,
+		disableAutoExpression: true,
+	}
+}
+
+// Common media_player states. Entities may report others, so custom values are allowed.
+export const MEDIA_PLAYER_STATES = ['playing', 'paused', 'idle', 'buffering', 'on', 'off', 'standby']
+
+export function MediaPlaybackStatePicker(): CompanionInputFieldDropdown<'state'> {
+	return {
+		type: 'dropdown',
+		label: 'State',
+		id: 'state',
+		default: 'playing',
+		choices: MEDIA_PLAYER_STATES.map((state) => ({ id: state, label: state })),
+		allowCustom: true,
 	}
 }
 

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -4,7 +4,7 @@ import type {
 	CompanionFeedbackInfo,
 } from '@companion-module/base'
 import type { HassEntities, HassEntity } from 'home-assistant-js-websocket'
-import { EntityPicker, OnOffPicker } from './choices.js'
+import { EntityPicker, MediaPlaybackStatePicker, OnOffPicker } from './choices.js'
 import { EntitySubscriptions } from './state.js'
 
 export type FeedbackId = keyof FeedbacksSchema
@@ -50,6 +50,20 @@ export type FeedbacksSchema = {
 		options: {
 			entity_id: string
 			state: boolean
+		}
+	}
+	media_playback_state: {
+		type: 'boolean'
+		options: {
+			entity_id: string
+			state: string
+		}
+	}
+	media_muted: {
+		type: 'boolean'
+		options: {
+			entity_id: string
+			muted: boolean
 		}
 	}
 }
@@ -181,6 +195,55 @@ export function GetFeedbacksList(
 			callback: (feedback): boolean => {
 				subscribeEntityPicker(feedback)
 				return checkEntityOnOffState(feedback)
+			},
+			unsubscribe: unsubscribeEntityPicker,
+		},
+		media_playback_state: {
+			type: 'boolean',
+			name: 'Change from media player playback state',
+			description: 'If the media player state matches the rule',
+			options: [EntityPicker(initialState, 'media_player'), MediaPlaybackStatePicker()],
+			defaultStyle: {
+				color: 0x000000,
+				bgcolor: 0x00ff00,
+			},
+			callback: (feedback): boolean => {
+				subscribeEntityPicker(feedback)
+				const state = getState()
+				const entity = state[feedback.options.entity_id]
+				if (entity) {
+					return entity.state === feedback.options.state
+				}
+				return false
+			},
+			unsubscribe: unsubscribeEntityPicker,
+		},
+		media_muted: {
+			type: 'boolean',
+			name: 'Change from media player mute state',
+			description: 'If the media player mute state matches the rule',
+			options: [
+				EntityPicker(initialState, 'media_player'),
+				{
+					type: 'checkbox',
+					label: 'Muted',
+					id: 'muted',
+					default: true,
+				},
+			],
+			defaultStyle: {
+				color: 0x000000,
+				bgcolor: 0x00ff00,
+			},
+			callback: (feedback): boolean => {
+				subscribeEntityPicker(feedback)
+				const state = getState()
+				const entity = state[feedback.options.entity_id]
+				if (entity) {
+					const isMuted = !!entity.attributes?.is_volume_muted
+					return isMuted === !!feedback.options.muted
+				}
+				return false
 			},
 			unsubscribe: unsubscribeEntityPicker,
 		},

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,6 +4,19 @@ export enum OnOffToggle {
 	Toggle = 'toggle',
 }
 
+export enum MediaPlayback {
+	Play = 'play',
+	Pause = 'pause',
+	PlayPause = 'play_pause',
+	Stop = 'stop',
+}
+
+export enum MuteToggle {
+	Mute = 'mute',
+	Unmute = 'unmute',
+	Toggle = 'toggle',
+}
+
 export function assertUnreachable(_never: never): void {
 	// throw new Error('Unreachable')
 }


### PR DESCRIPTION
### What

First-class support for `media_player` entities.

**Actions**
- Media: Set playback — dropdown: Play / Pause / Play-Pause / Stop (`media_play`, `media_pause`, `media_play_pause`, `media_stop`)
- Media: Next track / Previous track
- Media: Set mute — Mute / Unmute / Toggle (`volume_mute`; Toggle inverts the current `is_volume_muted`, since there is no mute-toggle service)
- Media: Volume up / down (`volume_up` / `volume_down`)
- Media: Set volume (percentage) — 0-100% slider → `volume_set` `volume_level`
- Media: Adjust volume by amount (percentage) — reads the current `volume_level` and nudges it, clamped to 0-100%
- Media: Set power — On / Off / Toggle (`turn_on` / `turn_off` / native `toggle`)

**Feedbacks**
- Media player playback state (matches `playing` / `paused` / `idle` / `off` …; custom values allowed)
- Media player mute state (matches `is_volume_muted`)

### Notes

`media_title`, `media_artist`, `volume_level` and `source` are already available through the generic `entity.<id>.attributes.<attr>` variables, so no new variables are added. No preset in this MVP.

### Testing

`yarn build` and `yarn lint` pass. HELP.md and the README changelog are updated.